### PR TITLE
[CO 281] Use Options.Applicative for parsing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
 with import <nixpkgs> {};
 
 let
-  ghc = haskellPackages.ghcWithPackages (ps: with ps; [ zip-archive regex-tdfa reflection aeson http-conduit attoparsec ]);
+  ghc = haskellPackages.ghcWithPackages (ps: with ps; [aeson array attoparsec bytestring containers http-conduit
+                                                       mtl optparse-applicative regex-tdfa reflection zip-archive]);
 in runCommand "log-classifier" { buildInputs = [ ghc haskellPackages.ghcid ]; } ''
   cp -r ${builtins.fetchGit ./.} src
   chmod -R +w src

--- a/log-classifier.cabal
+++ b/log-classifier.cabal
@@ -16,6 +16,7 @@ cabal-version:       >= 1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Classify
+                       CLI
                        Lib
                        LogAnalysis.Classifier
                        LogAnalysis.KnowledgeCSVParser

--- a/log-classifier.cabal
+++ b/log-classifier.cabal
@@ -34,6 +34,7 @@ library
                      , containers
                      , http-conduit
                      , mtl
+                     , optparse-applicative
                      , reflection
                      , regex-tdfa
                      , text

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -10,24 +10,26 @@ import           Options.Applicative (Parser, argument, auto, command, execParse
 import           Paths_log_classifier (version)
 
 data CLI
-    = CollectEmails
-    | ProcessTicket Int
-    | ProcessTickets
-    | RawRequest String
-    | ShowStatistics
-    deriving (Eq, Show)
+    = CollectEmails     -- ^ Collect email addresses
+    | ProcessTicket Int -- ^ Process ticket of an given ticket id
+    | ProcessTickets    -- ^ Procss all the tickets in the Zendesk
+    | RawRequest String -- ^ Raw requestto the given url
+    | ShowStatistics    -- ^ Show statistics
+    deriving (Show)
 
--- How do I dispaly helper..
+-- | Parser for ProcessTicket
 cmdProcessTicket :: Parser CLI
 cmdProcessTicket = ProcessTicket <$> argument auto
                        ( metavar "TICKET_ID"
                       <> help "Specify ticket id to analyze")
 
+-- | Parser for RawRequest
 cmdRawRequest :: Parser CLI
 cmdRawRequest = RawRequest <$> strOption
                     ( metavar "URL"
                    <> help "Specify url to request")
 
+-- | Parser for CLI commands
 cli :: Parser CLI
 cli = subparser $ mconcat
         [

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -1,36 +1,47 @@
 module CLI
-    ( getCliArgument
+    ( CLI(..)
+    , getCliArgs
     ) where
 
 import           Data.Semigroup ((<>))
-import           Options.Applicative
+import           Options.Applicative (Parser, argument, auto, command, execParser, fullDesc, header,
+                                      help, helper, info, infoOption, long, metavar, progDesc,
+                                      strOption, subparser, (<**>))
 import           Paths_log_classifier (version)
-
 
 data CLI
     = CollectEmails
     | ProcessTicket Int
     | ProcessTickets
+    | RawRequest String
     | ShowStatistics
     deriving (Eq, Show)
 
+-- How do I dispaly helper..
 cmdProcessTicket :: Parser CLI
-cmdProcessTicket = ProcessTicket <$> 
-                  argument auto (metavar "TICKET_ID"
-                              <> help "Specify ticket id to analyze")
+cmdProcessTicket = ProcessTicket <$> argument auto
+                       ( metavar "TICKET_ID"
+                      <> help "Specify ticket id to analyze")
+
+cmdRawRequest :: Parser CLI
+cmdRawRequest = RawRequest <$> strOption
+                    ( metavar "URL"
+                   <> help "Specify url to request")
 
 cli :: Parser CLI
-cli = subparser
-        (
+cli = subparser $ mconcat
+        [
           command "collectEmails" (info (pure CollectEmails)
             (progDesc "Collect emails requested by single user"))
-      <> command "processTickets" (info (pure ProcessTickets)
+        , command "processTickets" (info (pure ProcessTickets)
             (progDesc "Process all the tickets i.e add comments, tags."))
-      <> command "processTicket" (info cmdProcessTicket
+        , command "processTicket" (info cmdProcessTicket
             (progDesc "Process Zendesk ticket of an given <TICKET_ID>"))
-      <> command "showStats" (info (pure ShowStatistics)
+        , command "rawRequest" (info cmdRawRequest
+            (progDesc "Raw request to the given url"))
+        , command "showStats" (info (pure ShowStatistics)
             (progDesc "Print list of ticket Ids that agent has been assigned"))
-        )
+        ]
 
 getCliArgs :: IO CLI
 getCliArgs = execParser opts
@@ -44,4 +55,4 @@ getCliArgs = execParser opts
             infoOption
               ("Log classifier version" <> show version)
               (long "version" <> help "Show version")
-  
+

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -5,8 +5,8 @@ module CLI
 
 import           Data.Semigroup ((<>))
 import           Options.Applicative (Parser, argument, auto, command, execParser, fullDesc, header,
-                                      help, helper, info, infoOption, long, metavar, progDesc,
-                                      strOption, subparser, (<**>))
+                                      help, helper, hsubparser, info, infoOption, long, metavar,
+                                      progDesc, strOption, (<**>))
 import           Paths_log_classifier (version)
 
 data CLI
@@ -21,24 +21,24 @@ data CLI
 cmdProcessTicket :: Parser CLI
 cmdProcessTicket = ProcessTicket <$> argument auto
                        ( metavar "TICKET_ID"
-                      <> help "Specify ticket id to analyze")
+                      <> help "Ticket id to analyze")
 
 -- | Parser for RawRequest
 cmdRawRequest :: Parser CLI
 cmdRawRequest = RawRequest <$> strOption
                     ( metavar "URL"
-                   <> help "Specify url to request")
+                   <> help "Url to request")
 
 -- | Parser for CLI commands
 cli :: Parser CLI
-cli = subparser $ mconcat
+cli = hsubparser $ mconcat
         [
           command "collectEmails" (info (pure CollectEmails)
             (progDesc "Collect emails requested by single user"))
         , command "processTickets" (info (pure ProcessTickets)
             (progDesc "Process all the tickets i.e add comments, tags."))
         , command "processTicket" (info cmdProcessTicket
-            (progDesc "Process Zendesk ticket of an given <TICKET_ID>"))
+            (progDesc "Process Zendesk ticket of an given ticket id"))
         , command "rawRequest" (info cmdRawRequest
             (progDesc "Raw request to the given url"))
         , command "showStats" (info (pure ShowStatistics)
@@ -53,8 +53,6 @@ getCliArgs = execParser opts
             <> header "Log classifier"
             <> progDesc "Client for peforming analysis on Zendesk"
             )
-        versionHelper =
-            infoOption
-              ("Log classifier version" <> show version)
-              (long "version" <> help "Show version")
-
+        versionHelper = infoOption
+            ("Log classifier version" <> show version)
+            (long "version" <> help "Show version")

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -1,0 +1,47 @@
+module CLI
+    ( getCliArgument
+    ) where
+
+import           Data.Semigroup ((<>))
+import           Options.Applicative
+import           Paths_log_classifier (version)
+
+
+data CLI
+    = CollectEmails
+    | ProcessTicket Int
+    | ProcessTickets
+    | ShowStatistics
+    deriving (Eq, Show)
+
+cmdProcessTicket :: Parser CLI
+cmdProcessTicket = ProcessTicket <$> 
+                  argument auto (metavar "TICKET_ID"
+                              <> help "Specify ticket id to analyze")
+
+cli :: Parser CLI
+cli = subparser
+        (
+          command "collectEmails" (info (pure CollectEmails)
+            (progDesc "Collect emails requested by single user"))
+      <> command "processTickets" (info (pure ProcessTickets)
+            (progDesc "Process all the tickets i.e add comments, tags."))
+      <> command "processTicket" (info cmdProcessTicket
+            (progDesc "Process Zendesk ticket of an given <TICKET_ID>"))
+      <> command "showStats" (info (pure ShowStatistics)
+            (progDesc "Print list of ticket Ids that agent has been assigned"))
+        )
+
+getCliArgs :: IO CLI
+getCliArgs = execParser opts
+      where
+        opts = info (cli <**> helper <**> versionHelper)
+            ( fullDesc
+            <> header "Log classifier"
+            <> progDesc "Client for peforming analysis on Zendesk"
+            )
+        versionHelper =
+            infoOption
+              ("Log classifier version" <> show version)
+              (long "version" <> help "Show version")
+  

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -13,7 +13,7 @@ data CLI
     = CollectEmails     -- ^ Collect email addresses
     | ProcessTicket Int -- ^ Process ticket of an given ticket id
     | ProcessTickets    -- ^ Procss all the tickets in the Zendesk
-    | RawRequest String -- ^ Raw requestto the given url
+    | RawRequest String -- ^ Raw request to the given url
     | ShowStatistics    -- ^ Show statistics
     deriving (Show)
 

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -33,15 +33,15 @@ cmdRawRequest = RawRequest <$> strOption
 cli :: Parser CLI
 cli = hsubparser $ mconcat
         [
-          command "collectEmails" (info (pure CollectEmails)
+          command "collect-emails" (info (pure CollectEmails)
             (progDesc "Collect emails requested by single user"))
-        , command "processTickets" (info (pure ProcessTickets)
+        , command "process-tickets" (info (pure ProcessTickets)
             (progDesc "Process all the tickets i.e add comments, tags."))
-        , command "processTicket" (info cmdProcessTicket
+        , command "process-ticket" (info cmdProcessTicket
             (progDesc "Process Zendesk ticket of an given ticket id"))
-        , command "rawRequest" (info cmdRawRequest
+        , command "raw-request" (info cmdRawRequest
             (progDesc "Raw request to the given url"))
-        , command "showStats" (info (pure ShowStatistics)
+        , command "show-stats" (info (pure ShowStatistics)
             (progDesc "Print list of ticket Ids that agent has been assigned"))
         ]
 


### PR DESCRIPTION
## Description

Use `Options.Applicative` for parsing. Something similar to [this](https://github.com/input-output-hk/cardano-sl/blob/develop/tools/src/dbgen/CLI.hs)

```terminal
Log classifier

Usage: <interactive> COMMAND [--version]
  Client for peforming analysis on Zendesk

Available options:
  -h,--help                Show this help text
  --version                Show version

Available commands:
  collect-emails           Collect emails requested by single user
  process-tickets          Process all the tickets i.e add comments, tags.
  process-ticket           Process Zendesk ticket of an given ticket id
  raw-request              Raw request to the given url
  show-stats               Print list of ticket Ids that agent has been assigned
```

## Linked Issues

https://iohk.myjetbrains.com/youtrack/issue/CO-281

## Notes

I opted to implement as commands instead of arguments since [runZendeskMain](https://github.com/input-output-hk/log-classifier/blob/master/src/Zendesk.hs#L79) seemed like it's expecting command instead of argument.

I did try to implement like the [example](https://github.com/input-output-hk/cardano-sl/blob/develop/tools/src/dbgen/CLI.hs) but for some reason, `--help` command doesn't work.