### PR TITLE
[CO-290] Change Zendesk response template

### DIFF
--- a/src/LogAnalysis/Classifier.hs
+++ b/src/LogAnalysis/Classifier.hs
@@ -17,6 +17,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Text.Encoding.Error (ignore)
 import           Data.Text (isInfixOf)
 
+import           Types (TicketURL)
 import           LogAnalysis.Types (Analysis, Knowledge (..), renderErrorCode)
 
 -- | Number of error texts it should show
@@ -63,11 +64,11 @@ prettyHeader =
     "Thank you for contacting the IOHK Technical Support Desk. We appologize for the delay in responding to you. " <>
     "\n"
 
-prettyFooter :: Text
-prettyFooter =
-    "\n" <>
-    "Please be patient since we have a large number of such requests to respond to. We will respond as soon as we can, but in the meantime, if you want to check the status of your ticket you can do so here." <>
-    "\n" <>
+prettyFooter :: TicketURL -> Text
+prettyFooter ticketUrl =
+    "\n\n" <>
+        "Please be patient since we have a large number of such requests to respond to. We will respond as soon as we can, but in the meantime, if you want to check the status of your ticket you can do so here - " <> ticketUrl <>
+    "\n\n" <>
     "Please let us know if your issue is resolved. If you are still having trouble please reply back to this email and attach a new log file so that we can work with you to fix your problem." <>
     "\n" <>
     "Thanks, " <>
@@ -76,24 +77,26 @@ prettyFooter =
     "\n"
 
 -- | We need to fix this, this will pick the last issue found.
-prettyFormatAnalysis :: Analysis -> Text
-prettyFormatAnalysis as =
+prettyFormatAnalysis :: Analysis -> TicketURL -> Text
+prettyFormatAnalysis as ticketUrl =
     prettyHeader <>
-    show foundIssues <>
-    prettyFooter
+    prettyIssueComment <>
+    foundIssues <>
+    prettyFooter ticketUrl
   where
-    foundIssues = foldr (\(Knowledge{..}, _) acc -> acc <> foundIssuesTemplate kFAQNumber) "" $ Map.toList as
-    foundIssuesTemplate kFAQNumber = "\n" <> "We have analyzed the log that you submitted and it appears that your issue is addressed in the Daedalus FAQ in Issue " <> kFAQNumber <> ". Please go to https://daedaluswallet.io/faq/ and check Issue " <> kFAQNumber <> " to resolve your problem." <> "\n\n"
+    prettyIssueComment  = "Thank you for contacting the IOHK Technical Support Desk. We apologize for the delay in responding to you. We have analyzed the log that you submitted and it appears that your issue is addressed in the Daedalus FAQ Please go to https://daedaluswallet.io/faq/ and check FAQ Issue(s) listed below to resolve your problem:"
+    foundIssues         =
+        foldr (\(Knowledge{..}, _) acc -> acc <> "\n - " <> kFAQNumber <> ", " <> kProblem) "" $ Map.toList as
 
-prettyFormatNoIssues :: Text
-prettyFormatNoIssues =
+prettyFormatNoIssues :: TicketURL -> Text
+prettyFormatNoIssues ticketUrl =
     prettyHeader <>
-    "We have analyzed the log that you submitted and it appears that you do not have an identifiable technical issue." <>
-    prettyFooter
+    "We have analyzed the log that you submitted and it appears that you do not have an identifiable technical issue. Please be patient while our developers analyze this issue further since we have a large number of such requests to respond to." <>
+    prettyFooter ticketUrl
 
-prettyFormatLogReadError :: Text
-prettyFormatLogReadError =
+prettyFormatLogReadError :: TicketURL -> Text
+prettyFormatLogReadError ticketUrl =
     prettyHeader <>
-    "We tried to analyze the log that you submitted and it appears that your log cannot be processed. Please try attaching the log file once again in the agreed format." <>
-    prettyFooter
+    "Thank you for contacting the IOHK Technical Support Desk. We apologize for the delay in responding to you. We tried to analyze the log that you submitted and it appears that your log cannot be processed. Please try sending the log file once again. Please go to https://daedaluswallet.io/faq/ and see Issue 200 for instructions. Please reply to this email with when you respond." <>
+    prettyFooter ticketUrl
 

--- a/src/LogAnalysis/Classifier.hs
+++ b/src/LogAnalysis/Classifier.hs
@@ -14,11 +14,11 @@ import           Universum
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
-import           Data.Text.Encoding.Error (ignore)
 import           Data.Text (isInfixOf)
+import           Data.Text.Encoding.Error (ignore)
 
-import           Types (TicketURL)
 import           LogAnalysis.Types (Analysis, Knowledge (..), renderErrorCode)
+import           Types (TicketInfo (..))
 
 -- | Number of error texts it should show
 numberOfErrorText :: Int
@@ -56,6 +56,10 @@ filterAnalysis as = do
 extractErrorCodes :: Analysis -> [ Text ]
 extractErrorCodes as = map (\(Knowledge{..}, _) -> renderErrorCode kErrorCode) $ Map.toList as
 
+
+printTicketUrl :: TicketInfo -> Text
+printTicketUrl TicketInfo{..} = "https://iohk.zendesk.com/agent/tickets/" <> show ticketId
+
 prettyHeader :: Text
 prettyHeader =
     "Dear user," <>
@@ -64,39 +68,39 @@ prettyHeader =
     "Thank you for contacting the IOHK Technical Support Desk. We appologize for the delay in responding to you. " <>
     "\n"
 
-prettyFooter :: TicketURL -> Text
-prettyFooter ticketUrl =
+prettyFooter :: TicketInfo -> Text
+prettyFooter ticketInfo =
     "\n\n" <>
-        "Please be patient since we have a large number of such requests to respond to. We will respond as soon as we can, but in the meantime, if you want to check the status of your ticket you can do so here - " <> ticketUrl <>
+        "Please be patient since we have a large number of such requests to respond to. We will respond as soon as we can, but in the meantime, if you want to check the status of your ticket you can do so here - " <> printTicketUrl ticketInfo <>
     "\n\n" <>
     "Please let us know if your issue is resolved. If you are still having trouble please reply back to this email and attach a new log file so that we can work with you to fix your problem." <>
-    "\n" <>
+    "\n\n" <>
     "Thanks, " <>
     "\n" <>
     "The IOHK Technical Support Desk Team" <>
     "\n"
 
 -- | We need to fix this, this will pick the last issue found.
-prettyFormatAnalysis :: Analysis -> TicketURL -> Text
-prettyFormatAnalysis as ticketUrl =
+prettyFormatAnalysis :: Analysis -> TicketInfo -> Text
+prettyFormatAnalysis as ticketInfo =
     prettyHeader <>
     prettyIssueComment <>
     foundIssues <>
-    prettyFooter ticketUrl
+    prettyFooter ticketInfo
   where
-    prettyIssueComment  = "Thank you for contacting the IOHK Technical Support Desk. We apologize for the delay in responding to you. We have analyzed the log that you submitted and it appears that your issue is addressed in the Daedalus FAQ Please go to https://daedaluswallet.io/faq/ and check FAQ Issue(s) listed below to resolve your problem:"
+    prettyIssueComment  = "We have analyzed the log that you submitted and it appears that your issue is addressed in the Daedalus FAQ Please go to https://daedaluswallet.io/faq/ and check FAQ Issue(s) listed below to resolve your problem:"
     foundIssues         =
-        foldr (\(Knowledge{..}, _) acc -> acc <> "\n - " <> kFAQNumber <> ", " <> kProblem) "" $ Map.toList as
+        foldr (\(Knowledge{..}, _) acc -> acc <> "\n- " <> kFAQNumber) "" $ Map.toList as
 
-prettyFormatNoIssues :: TicketURL -> Text
-prettyFormatNoIssues ticketUrl =
+prettyFormatNoIssues :: TicketInfo -> Text
+prettyFormatNoIssues ticketInfo =
     prettyHeader <>
     "We have analyzed the log that you submitted and it appears that you do not have an identifiable technical issue. Please be patient while our developers analyze this issue further since we have a large number of such requests to respond to." <>
-    prettyFooter ticketUrl
+    prettyFooter ticketInfo
 
-prettyFormatLogReadError :: TicketURL -> Text
-prettyFormatLogReadError ticketUrl =
+prettyFormatLogReadError :: TicketInfo -> Text
+prettyFormatLogReadError ticketInfo =
     prettyHeader <>
-    "Thank you for contacting the IOHK Technical Support Desk. We apologize for the delay in responding to you. We tried to analyze the log that you submitted and it appears that your log cannot be processed. Please try sending the log file once again. Please go to https://daedaluswallet.io/faq/ and see Issue 200 for instructions. Please reply to this email with when you respond." <>
-    prettyFooter ticketUrl
+    "We tried to analyze the log that you submitted and it appears that your log cannot be processed. Please try sending the log file once again. Please go to https://daedaluswallet.io/faq/ and see Issue 200 for instructions. Please reply to this email with when you respond." <>
+    prettyFooter ticketInfo
 

--- a/src/LogAnalysis/Types.hs
+++ b/src/LogAnalysis/Types.hs
@@ -46,20 +46,21 @@ data Knowledge = Knowledge
     -- ^ The FAQ number that will be displayed on the official Cardano FAQ page
     } deriving (Show)
 
+-- | Sorted accoring to knowledgebase.
 renderErrorCode :: ErrorCode -> Text
-renderErrorCode ShortStorage      = "short-storage"
-renderErrorCode UserNameError     = "user-name-error"
-renderErrorCode TimeSync          = "time-out-of-sync"
-renderErrorCode FileNotFound      = "directory-not-found"
-renderErrorCode StaleLockFile     = "stale-lock-file"
-renderErrorCode SentLogCorrupted  = "sent-log-corrupted"
 renderErrorCode DBError           = "DB-corrupted"
+renderErrorCode StaleLockFile     = "stale-lock-file"
+renderErrorCode FileNotFound      = "directory-not-found"
+renderErrorCode ShortStorage      = "short-storage"
+renderErrorCode NetworkError      = "network-error"
+renderErrorCode BalanceError      = "incorrect-balance"
+renderErrorCode ResourceVanished  = "resource-vanished"
+renderErrorCode UserNameError     = "user-name-error"
+renderErrorCode ConnectionRefused = "connection-refused"
+renderErrorCode TimeSync          = "time-out-of-sync"
+renderErrorCode SentLogCorrupted  = "sent-log-corrupted"
 renderErrorCode DBPath            = "DB-path-error"
 renderErrorCode CannotGetDBSize   = "cannot-get-db-size"
-renderErrorCode BalanceError      = "incorrect-balance"
-renderErrorCode NetworkError      = "network-error"
-renderErrorCode ConnectionRefused = "connection-refused"
-renderErrorCode ResourceVanished  = "resource-vanished"
 renderErrorCode Unknown           = "unknown"
 renderErrorCode Error             = "error"
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -8,6 +8,7 @@ module Types
     , Ticket(..)
     , TicketList(..)
     , TicketId
+    , TicketURL
     , TicketInfo(..)
     , TicketTag(..)
     , parseAgentId
@@ -76,12 +77,17 @@ data TicketList = TicketList
     }
 
 type TicketId = Int
+type TicketURL = Text -- TODO(ks): We should wrap all these...
 
 data TicketInfo = TicketInfo
     { ticketId      :: !TicketId    -- ^ Id of an ticket
+    , ticketUrl     :: !TicketURL   -- ^ The ticket URL
     , ticketTags    :: ![Text]      -- ^ Tags associated with ticket
     , ticketStatus  :: !Text        -- ^ The status of the ticket
-    } deriving (Eq)
+    } deriving (Eq, Show)
+
+instance Ord TicketInfo where
+    compare t1 t2 = compare (ticketId t1) (ticketId t2)
 
 -- | Ticket tag
 data TicketTag
@@ -123,6 +129,7 @@ instance ToJSON Attachment where
 instance FromJSON TicketInfo where
     parseJSON = withObject "ticket" $ \o -> do
         ticketId        <- o .: "id"
+        ticketUrl       <- o .: "url"
         ticketTags      <- o .: "tags"
         ticketStatus    <- o .: "status"
 

--- a/src/Zendesk.hs
+++ b/src/Zendesk.hs
@@ -281,13 +281,17 @@ filterAnalyzedTickets ticketsInfo =
   where
     ticketsFilter :: TicketInfo -> Bool
     ticketsFilter ticketInfo =
-        isTicketAnalyzed ticketInfo && isTicketOpen ticketInfo
+        isTicketAnalyzed ticketInfo && isTicketOpen ticketInfo && isTicketBlacklisted ticketInfo
 
     isTicketAnalyzed :: TicketInfo -> Bool
     isTicketAnalyzed TicketInfo{..} = (renderTicketStatus AnalyzedByScript) `notElem` ticketTags
 
     isTicketOpen :: TicketInfo -> Bool
     isTicketOpen TicketInfo{..} = ticketStatus == "open" -- || ticketStatus == "new"
+
+    -- | If we have a ticket we are having issues with...
+    isTicketBlacklisted :: TicketInfo -> Bool
+    isTicketBlacklisted TicketInfo{..} = ticketId `notElem` [10815]
 
 
 -- | Get single ticket info.


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/issue/CO-290

Fixed some smaller issues so we can run it over the weekend.

Testing:
```
let knowledge = Knowledge mempty LogAnalysis.Types.NetworkError "Daedalus Wallet Support Issue 11 Firewall is blocking the connection" mempty "234"
import Data.Map
let analysis = singleton knowledge ["Network.Socket.recvBuf: resource vanished"]
let ticketInfo = TicketInfo {ticketId = 17803, ticketUrl = "https://iohk.zendesk.com/api/v2/tickets/17803.json", ticketTags = [], ticketStatus = "open"}

prettyFormatAnalysis analysis ticketInfo
```

Example response:
```
Dear user,

Thank you for contacting the IOHK Technical Support Desk. We appologize for the delay in responding to you. 
We have analyzed the log that you submitted and it appears that your issue is addressed in the Daedalus FAQ Please go to https://daedaluswallet.io/faq/ and check FAQ Issue(s) listed below to resolve your problem:
- 234

Please be patient since we have a large number of such requests to respond to. We will respond as soon as we can, but in the meantime, if you want to check the status of your ticket you can do so here - https://iohk.zendesk.com/agent/tickets/17803

Please let us know if your issue is resolved. If you are still having trouble please reply back to this email and attach a new log file so that we can work with you to fix your problem.

Thanks, 
The IOHK Technical Support Desk Team
```