### PR TITLE
[TSD-59] Keep existing tags, fields as it is after processing the ticket

### DIFF
--- a/src/DataSource/DB.hs
+++ b/src/DataSource/DB.hs
@@ -23,6 +23,7 @@ import           Database.SQLite.Simple.ToField (ToField (..))
 
 import           DataSource.Types (Attachment (..), AttachmentContent (..), AttachmentId (..),
                                    Comment (..), CommentBody (..), CommentId (..), Config,
+                                   TicketField (..), TicketFieldId (..), TicketFieldValue (..),
                                    TicketId (..), TicketInfo (..), TicketStatus (..),
                                    TicketTags (..), TicketURL (..), UserId (..), ZendeskLayer (..))
 
@@ -46,6 +47,17 @@ cachedZendeskLayer = ZendeskLayer
 -- Database instances
 -- FROM
 
+instance FromField TicketFieldId where
+    fromField (Field (SQLInteger tfId) _)     = Ok . TicketFieldId . fromIntegral $ tfId
+    fromField f                             = returnError ConversionFailed f "need a text, ticket status"
+
+instance FromField TicketFieldValue where
+    fromField (Field (SQLText tfValue) _)     = Ok . TicketFieldValue $ tfValue
+    fromField f                             = returnError ConversionFailed f "need a text, ticket status"
+
+instance FromField [TicketField] where
+    fromField _ = undefined
+
 instance FromField TicketId where
     fromField (Field (SQLInteger tId) _)    = Ok . TicketId . fromIntegral $ tId
     fromField f                             = returnError ConversionFailed f "need an integer, ticket id"
@@ -68,7 +80,7 @@ instance FromField TicketStatus where
     fromField f                             = returnError ConversionFailed f "need a text, ticket status"
 
 instance FromRow TicketInfo where
-    fromRow = TicketInfo <$> field <*> field <*> field <*> field <*> field <*> field
+    fromRow = TicketInfo <$> field <*> field <*> field <*> field <*> field <*> field <*> field <*> field
 
 instance FromField CommentId where
     fromField (Field (SQLInteger commId) _) = Ok . CommentId . fromIntegral $ commId

--- a/src/DataSource/Http.hs
+++ b/src/DataSource/Http.hs
@@ -41,7 +41,7 @@ defaultConfig =
         , cfgAssignTo           = 0
         , cfgKnowledgebase      = []
         , cfgNumOfLogsToAnalyze = 5
-        , cfgIsCommentPublic    = False -- TODO(ks): For now, we need this in CLI.
+        , cfgIsCommentPublic    = True -- TODO(ks): For now, we need this in CLI.
         , cfgZendeskLayer       = basicZendeskLayer
         , cfgIOLayer            = basicIOLayer
         }

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -464,7 +464,7 @@ instance Arbitrary TicketInfo where
             , tiTags        = ticketTags
             , tiStatus      = ticketStatus
             , tiField       = ticketField
-            , tiCustomField  = ticketCustomField
+            , tiCustomField = ticketCustomField
             }
 
 instance Arbitrary UserId where

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -267,7 +267,7 @@ data ZendeskResponse = ZendeskResponse
     , zrComment  :: !Text
     , zrTags     :: !TicketTags
     , zrIsPublic :: !Bool
-    }
+    } deriving (Eq, Show)
 
 newtype CommentId = CommentId
     { getCommentId :: Int
@@ -500,6 +500,21 @@ instance Arbitrary User where
             , uName = userName
             , uEmail = userEmail
             }
+    
+instance Arbitrary ZendeskResponse where
+    arbitrary = do
+        zendeskResponseTicketId <- arbitrary
+        zendeskResponseComment  <- fromString <$> arbitrary
+        zendeskResponseTags     <- arbitrary
+        zendeskResponseIsPublic <- arbitrary
+
+        pure ZendeskResponse
+            { zrTicketId = zendeskResponseTicketId
+            , zrComment  = zendeskResponseComment
+            , zrTags     = zendeskResponseTags
+            , zrIsPublic = zendeskResponseIsPublic
+            }
+
 ------------------------------------------------------------
 -- FromJSON instances
 ------------------------------------------------------------

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -14,6 +14,9 @@ module DataSource.Types
     , PageResultList (..)
     , RequestType (..)
     , Ticket (..)
+    , TicketField (..)
+    , TicketFieldId (..)
+    , TicketFieldValue (..)
     , TicketId (..)
     , TicketURL (..)
     , TicketTags (..)
@@ -131,14 +134,14 @@ assignToPath = "./tmp-secrets/assign_to"
 -- We don't want anything to leak out, so we expose only the most relevant information,
 -- anything relating to how it internaly works should NOT be exposed.
 data ZendeskLayer m = ZendeskLayer
-    { zlGetTicketInfo         :: TicketId         -> m (Maybe TicketInfo)
-    , zlListRequestedTickets  :: UserId           -> m [TicketInfo]
-    , zlListAssignedTickets   :: UserId           -> m [TicketInfo]
-    , zlListUnassignedTickets ::                     m [TicketInfo]
-    , zlListAdminAgents       ::                     m [User]
-    , zlGetTicketComments     :: TicketId         -> m [Comment]
-    , zlGetAttachment         :: Attachment       -> m (Maybe AttachmentContent)
-    , zlPostTicketComment     :: ZendeskResponse  -> m ()
+    { zlGetTicketInfo         :: TicketId                       -> m (Maybe TicketInfo)
+    , zlListRequestedTickets  :: UserId                         -> m [TicketInfo]
+    , zlListAssignedTickets   :: UserId                         -> m [TicketInfo]
+    , zlListUnassignedTickets ::                                   m [TicketInfo]
+    , zlListAdminAgents       ::                                   m [User]
+    , zlGetTicketComments     :: TicketId                       -> m [Comment]
+    , zlGetAttachment         :: Attachment                     -> m (Maybe AttachmentContent)
+    , zlPostTicketComment     :: TicketInfo -> ZendeskResponse  -> m ()
     }
 
 -- | The IOLayer interface that we can expose.
@@ -295,11 +298,26 @@ newtype CommentOuter = CommentOuter {
 
 -- | Zendesk ticket
 data Ticket = Ticket
-    { tComment :: !Comment
+    { tComment     :: !Comment
     -- ^ Ticket comment
-    , tTag      :: !TicketTags
+    , tTag         :: !TicketTags
+    , tField       :: ![TicketField]
+    , tCustomField :: ![TicketField]
     -- ^ Tags attached to ticket
     }
+
+newtype TicketFieldId = TicketFieldId
+    { getTicketFieldId :: Integer
+    } deriving (Eq, Show, Ord, Generic, FromJSON, ToJSON)
+
+newtype TicketFieldValue = TicketFieldValue
+    { getTicketFieldValue :: Text
+    } deriving (Eq, Show, Ord, Generic, FromJSON, ToJSON)
+
+data TicketField = TicketField
+    { tfId    :: TicketFieldId
+    , tfValue :: Maybe TicketFieldValue
+    } deriving (Eq, Show, Ord)
 
 -- TODO(ks): We need to verify this still works, we don't have any
 -- regression tests...
@@ -326,6 +344,8 @@ data TicketInfo = TicketInfo
     , tiUrl         :: !TicketURL       -- ^ The ticket URL
     , tiTags        :: !TicketTags      -- ^ Tags associated with ticket
     , tiStatus      :: !TicketStatus    -- ^ The status of the ticket
+    , tiField       :: ![TicketField]   -- ^ Custom field (e.g. Priority, Category)
+    , tiCustomField :: ![TicketField]   -- ^ No idea why but there's two fields..
     } deriving (Eq, Show, Generic)
 
 -- | Ticket tag
@@ -394,6 +414,17 @@ instance Arbitrary Comment where
         <*> arbitrary
         <*> arbitrary
 
+instance Arbitrary TicketFieldId where
+    arbitrary = TicketFieldId <$> arbitrary
+
+instance Arbitrary TicketFieldValue where
+    arbitrary = TicketFieldValue . fromString <$> arbitrary
+
+instance Arbitrary TicketField where
+    arbitrary = TicketField
+        <$> arbitrary
+        <*> arbitrary
+
 instance Arbitrary TicketId where
     arbitrary = TicketId <$> arbitrary
 
@@ -421,6 +452,9 @@ instance Arbitrary TicketInfo where
         ticketUrl           <- arbitrary
         ticketTags          <- arbitrary
         ticketStatus        <- arbitrary
+        ticketField         <- arbitrary
+        ticketCustomField   <- arbitrary
+
 
         pure TicketInfo
             { tiId          = ticketId
@@ -429,6 +463,8 @@ instance Arbitrary TicketInfo where
             , tiUrl         = ticketUrl
             , tiTags        = ticketTags
             , tiStatus      = ticketStatus
+            , tiField       = ticketField
+            , tiCustomField  = ticketCustomField
             }
 
 instance Arbitrary UserId where
@@ -499,6 +535,16 @@ instance FromJSON Comment where
             , cAuthor      = commentAuthorId
             }
 
+instance FromJSON TicketField where
+    parseJSON = withObject "ticket field" $ \o -> do
+        ticketFieldId    <- o .: "id"
+        ticketFieldValue <- o .: "value"
+        
+        pure TicketField
+            { tfId    = ticketFieldId
+            , tfValue = ticketFieldValue
+            }
+
 class FromPageResultList a where
     fromPageResult :: Value -> Parser (PageResultList a)
 
@@ -541,6 +587,8 @@ instance FromJSON TicketInfo where
         ticketUrl           <- o .: "url"
         ticketTags          <- o .: "tags"
         ticketStatus        <- o .: "status"
+        ticketField         <- o .: "fields"
+        ticketCustomField   <- o .: "custom_fields"
 
         pure TicketInfo
             { tiId          = ticketId
@@ -549,6 +597,8 @@ instance FromJSON TicketInfo where
             , tiUrl         = ticketUrl
             , tiTags        = ticketTags
             , tiStatus      = ticketStatus
+            , tiField       = ticketField
+            , tiCustomField = ticketCustomField
             }
 
 instance FromJSON User where
@@ -590,11 +640,19 @@ instance ToJSON CommentOuter where
         object  [ "comment"         .= c
                 ]
 
+instance ToJSON TicketField where
+    toJSON (TicketField fid fvalue) =
+        object [ "id"               .= fid
+               , "value"            .= fvalue
+               ]
+
 instance ToJSON Ticket where
-    toJSON (Ticket comment tags) =
+    toJSON (Ticket comment tags fields customField) =
         object  [ "ticket" .= object
-                    [ "comment"     .= comment
-                    , "tags"        .= tags
+                    [ "comment"       .= comment
+                    , "tags"          .= tags
+                    , "fields"        .= fields
+                    , "custom_fields" .= customField
                     ]
                 ]
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -114,21 +114,15 @@ processTicket tId = do
     postTicketComment   <- asksZendeskLayer zlPostTicketComment
     
     whenJust zendeskResponse $ \response -> do
-        let formattedTags = formatZendeskResponseTags response
-        printText formattedTags
-        appendF <- asksIOLayer iolAppendFile
-        appendF "logs/analysis-result.log" (show (getTicketId tId) <> " " <> formattedTags <> "\n")
         postTicketComment ticketInfo response
+        let tags = getTicketTags $ zrTags response
+        forM_ tags $ \tag -> do
+            let formattedTicketIdAndTag = show (getTicketId tId) <> " " <> tag
+            printText formattedTicketIdAndTag
+            appendF <- asksIOLayer iolAppendFile
+            appendF "logs/analysis-result.log" (formattedTicketIdAndTag <> "\n")
 
     pure zendeskResponse
-
-formatZendeskResponseTags :: ZendeskResponse -> Text
-formatZendeskResponseTags zendeskResponse = do
-    let ticketTags = zrTags zendeskResponse
-    formatTags ticketTags
-  where
-    formatTags :: TicketTags -> Text
-    formatTags tags = foldr (\tag acc -> tag <> ";" <> acc) "" (getTicketTags tags)
 
 processTickets :: App ()
 processTickets = do
@@ -368,4 +362,3 @@ filterAnalyzedTickets ticketsInfo =
 
     isTicketInGoguenTestnet :: TicketInfo -> Bool
     isTicketInGoguenTestnet TicketInfo{..} = "goguen_testnets" `notElem` getTicketTags tiTags
-

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -111,7 +111,6 @@ processTicket tId = do
     let attachments     = getAttachmentsFromComment comments
     let ticketInfo      = fromMaybe (error "No ticket info") mTicketInfo
     zendeskResponse     <- getZendeskResponses comments attachments ticketInfo
-
     postTicketComment   <- asksZendeskLayer zlPostTicketComment
     
     whenJust zendeskResponse $ \response -> do
@@ -119,7 +118,7 @@ processTicket tId = do
         printText formattedTags
         appendF <- asksIOLayer iolAppendFile
         appendF "logs/analysis-result.log" (show (getTicketId tId) <> " " <> formattedTags <> "\n")
-        postTicketComment response
+        postTicketComment ticketInfo response
 
     pure zendeskResponse
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -46,9 +46,9 @@ withStubbedIOAndZendeskLayer stubbedZendeskLayer =
 
 listAndSortTicketsSpec :: Spec
 listAndSortTicketsSpec =
-    describe "listAndSortTickets" $ modifyMaxSuccess (const 200) $ do
-        it "doesn't return tickets since there are none" $ do
-            forAll arbitrary $ \(ticketInfo :: TicketInfo) -> do
+    describe "listAndSortTickets" $ modifyMaxSuccess (const 200) $
+        it "doesn't return tickets since there are none" $
+            forAll arbitrary $ \(ticketInfo :: TicketInfo) ->
 
                 monadicIO $ do
 
@@ -115,7 +115,7 @@ processTicketSpec =
                                 emptyZendeskLayer
                                     { zlListAssignedTickets     = \_     -> pure listTickets
                                     , zlGetTicketInfo           = \_     -> pure $ Just ticketInfo
-                                    , zlPostTicketComment       = \_     -> pure ()
+                                    , zlPostTicketComment       = \_ _   -> pure ()
                                     , zlGetTicketComments       = \_     -> pure []
                                     }
 
@@ -142,7 +142,7 @@ processTicketSpec =
                                 emptyZendeskLayer
                                     { zlListAssignedTickets     = \_     -> pure listTickets
                                     , zlGetTicketInfo           = \_     -> pure $ Just ticketInfo
-                                    , zlPostTicketComment       = \_     -> pure ()
+                                    , zlPostTicketComment       = \_ _    -> pure ()
                                     , zlGetTicketComments       = \_     -> pure comments
                                     , zlGetAttachment           = \_     -> pure $ Just mempty
                                     }
@@ -166,9 +166,9 @@ processTicketSpec =
                     let stubbedZendeskLayer :: ZendeskLayer App
                         stubbedZendeskLayer =
                             emptyZendeskLayer
-                                { zlGetTicketComments = \_ -> pure commentsWithoutAttachment
-                                , zlGetTicketInfo     = \_ -> pure $ Just ticketInfo
-                                , zlPostTicketComment = \_ -> pure ()
+                                { zlGetTicketComments = \_   -> pure commentsWithoutAttachment
+                                , zlGetTicketInfo     = \_   -> pure $ Just ticketInfo
+                                , zlPostTicketComment = \_ _ -> pure ()
                                 }
 
                     let stubbedConfig :: Config
@@ -192,10 +192,10 @@ processTicketSpec =
                     let stubbedZendeskLayer :: ZendeskLayer App
                         stubbedZendeskLayer =
                             emptyZendeskLayer
-                                { zlGetTicketComments = \_ -> pure comments
-                                , zlGetTicketInfo     = \_ -> pure $ Just ticketInfo
-                                , zlPostTicketComment = \_ -> pure ()
-                                , zlGetAttachment     = \_ -> pure $ Just mempty
+                                { zlGetTicketComments = \_   -> pure comments
+                                , zlGetTicketInfo     = \_   -> pure $ Just ticketInfo
+                                , zlPostTicketComment = \_ _ -> pure ()
+                                , zlGetAttachment     = \_   -> pure $ Just mempty
                                 }
 
                     let stubbedConfig :: Config
@@ -292,6 +292,8 @@ genTicketWithFilteredTags tagToBeFiltered = TicketInfo
     <*> arbitrary
     <*> return (TicketTags tagToBeFiltered)
     <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
 
 genTicketWithUnsolvedStatus :: Gen TicketInfo
 genTicketWithUnsolvedStatus = TicketInfo
@@ -301,3 +303,5 @@ genTicketWithUnsolvedStatus = TicketInfo
     <*> arbitrary
     <*> arbitrary
     <*> (TicketStatus <$> elements ["new", "hold", "open", "pending"])
+    <*> arbitrary
+    <*> arbitrary


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/issue/TSD-59

Description:
For some reason, Zendesk changes the values of the custom field to `null` when posting the comment unless we explicitly tell Zendesk not to change it.
Also, we've been overwriting the existing tags.

This PR will fix these issues.