### PR TITLE
[TSD-70] Exception handling when reading log files

### DIFF
--- a/log-classifier.cabal
+++ b/log-classifier.cabal
@@ -48,6 +48,7 @@ library
                      , optparse-applicative
                      , reflection
                      , regex-tdfa
+                     , safe-exceptions
                      , text
                      , time
                      , universum

--- a/log-classifier.cabal
+++ b/log-classifier.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Classify
                        CLI
+                       Exceptions
                        Lib
                        LogAnalysis.Classifier
                        LogAnalysis.KnowledgeCSVParser

--- a/log-classifier.cabal
+++ b/log-classifier.cabal
@@ -20,6 +20,7 @@ library
                        Exceptions
                        Lib
                        LogAnalysis.Classifier
+                       LogAnalysis.Exceptions
                        LogAnalysis.KnowledgeCSVParser
                        LogAnalysis.Types
                        Regex

--- a/log-classifier.cabal
+++ b/log-classifier.cabal
@@ -49,7 +49,6 @@ library
                      , optparse-applicative
                      , reflection
                      , regex-tdfa
-                     , safe-exceptions
                      , text
                      , time
                      , universum

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -11,7 +11,6 @@ module DataSource.Types
     , CommentId (..)
     , CommentBody (..)
     , CommentOuter (..)
-    , LogFiles(..)
     , PageResultList (..)
     , RequestType (..)
     , DeletedTicket (..)
@@ -348,10 +347,6 @@ data Comment = Comment
 -- | Outer comment ??
 newtype CommentOuter = CommentOuter {
       coComment :: Comment
-    }
-
-newtype LogFiles = LogFiles {
-    getLogFiles :: [LByteString]
     }
 
 -- | Zendesk ticket

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -11,6 +11,7 @@ module DataSource.Types
     , CommentId (..)
     , CommentBody (..)
     , CommentOuter (..)
+    , LogFiles(..)
     , PageResultList (..)
     , RequestType (..)
     , DeletedTicket (..)
@@ -347,6 +348,10 @@ data Comment = Comment
 -- | Outer comment ??
 newtype CommentOuter = CommentOuter {
       coComment :: Comment
+    }
+
+newtype LogFiles = LogFiles {
+    getLogFiles :: [LByteString]
     }
 
 -- | Zendesk ticket

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -411,7 +411,6 @@ data TicketTag
     | AnalyzedByScriptV1_2  -- ^ Ticket has been analyzed by the version 1.2
     | NoKnownIssue          -- ^ Ticket had no known issue
     | NoLogAttached         -- ^ Log file not attached
-    | CannotReadZipFile
 
 newtype UserId = UserId
     { getUserId :: Int
@@ -812,5 +811,4 @@ renderTicketStatus AnalyzedByScriptV1_0 = "analyzed-by-script-v1.0"
 renderTicketStatus AnalyzedByScriptV1_1 = "analyzed-by-script-v1.1"
 renderTicketStatus AnalyzedByScriptV1_2 = "analyzed-by-script-v1.2"
 renderTicketStatus NoKnownIssue         = "no-known-issues"
-renderTicketStatus CannotReadZipFile    = "cannot-read-zip-file"
 renderTicketStatus NoLogAttached        = "no-log-files"

--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -80,6 +80,8 @@ newtype App a = App { runAppBase :: ReaderT Config IO a }
              , MonadIO
              , MonadBase IO
              , MonadUnliftIO
+             , MonadCatch
+             , MonadThrow
              )
 
 instance MonadBaseControl IO App where
@@ -409,6 +411,7 @@ data TicketTag
     | AnalyzedByScriptV1_2  -- ^ Ticket has been analyzed by the version 1.2
     | NoKnownIssue          -- ^ Ticket had no known issue
     | NoLogAttached         -- ^ Log file not attached
+    | CannotReadZipFile
 
 newtype UserId = UserId
     { getUserId :: Int
@@ -809,4 +812,5 @@ renderTicketStatus AnalyzedByScriptV1_0 = "analyzed-by-script-v1.0"
 renderTicketStatus AnalyzedByScriptV1_1 = "analyzed-by-script-v1.1"
 renderTicketStatus AnalyzedByScriptV1_2 = "analyzed-by-script-v1.2"
 renderTicketStatus NoKnownIssue         = "no-known-issues"
+renderTicketStatus CannotReadZipFile    = "cannot-read-zip-file"
 renderTicketStatus NoLogAttached        = "no-log-files"

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -3,11 +3,11 @@ module Exceptions
     , ZipFileExceptions (..)
     ) where
 
-import Universum
+import           Universum
 
-import DataSource (TicketId(..))
+import           DataSource (TicketId (..))
 
-import Prelude (Show(..))
+import           Prelude (Show (..))
 
 -- | Exceptions that can occur during ticket processing
 data ProcessTicketExceptions

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -16,6 +16,7 @@ data ProcessTicketExceptions
     -- ^ TicketInfo is invalid (both attachment and comment were not found)
     | TicketInfoNotFound TicketId
     -- ^ TicketInfo could not be fetched
+    deriving (Eq)
 
 data ZipFileExceptions
     = ReadZipFileException

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -1,0 +1,9 @@
+module Exceptions where
+
+import Universum
+
+data ClassifierExceptions
+    = ReadZipFileException Text
+    deriving Show
+
+instance Exception ClassifierExceptions

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -3,7 +3,8 @@ module Exceptions where
 import Universum
 
 data ClassifierExceptions
-    = ReadZipFileException Text
+    = ReadZipFileException
+    | DecompressionException
     deriving Show
 
 instance Exception ClassifierExceptions

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -1,5 +1,5 @@
 module Exceptions
-    ( TicketInfoExceptions (..)
+    ( ProcessTicketExceptions (..)
     , ZipFileExceptions (..)
     ) where
 
@@ -7,10 +7,10 @@ import Universum
 
 import DataSource (TicketId)
 
-data TicketInfoExceptions
+data ProcessTicketExceptions
     = AttachmentNotFound TicketId
-    -- ^ Could not fetch the attachment
-    | InvalidTicketInfoException TicketId
+    -- ^ Could not fetch the attachment even though ticket info has the url of the attachment
+    | InvalidTicketInfo TicketId
     -- ^ TicketInfo is invalid (both attachment and comment were not found)
     | TicketInfoNotFound TicketId
     -- ^ TicketInfo could not be fetched
@@ -23,5 +23,5 @@ data ZipFileExceptions
     -- ^ Decompresson of a zip file was not sucessful
     deriving Show
 
-instance Exception TicketInfoExceptions
+instance Exception ProcessTicketExceptions
 instance Exception ZipFileExceptions

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -5,7 +5,9 @@ module Exceptions
 
 import Universum
 
-import DataSource (TicketId)
+import DataSource (TicketId(..))
+
+import Prelude (Show(..))
 
 data ProcessTicketExceptions
     = AttachmentNotFound TicketId
@@ -14,7 +16,6 @@ data ProcessTicketExceptions
     -- ^ TicketInfo is invalid (both attachment and comment were not found)
     | TicketInfoNotFound TicketId
     -- ^ TicketInfo could not be fetched
-    deriving Show
 
 data ZipFileExceptions
     = ReadZipFileException
@@ -25,3 +26,11 @@ data ZipFileExceptions
 
 instance Exception ProcessTicketExceptions
 instance Exception ZipFileExceptions
+
+instance Show ProcessTicketExceptions where
+    show (AttachmentNotFound tid) = "Attachment was not found on ticket ID: " <> showTicketId tid
+    show (InvalidTicketInfo tid)  = "Ticket information is invalid on ticket ID: " <> showTicketId tid
+    show (TicketInfoNotFound tid) = "Ticket information was not found on ticket ID: " <> showTicketId tid
+
+showTicketId :: TicketId -> String
+showTicketId tid = Universum.show (getTicketId tid)

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -1,10 +1,27 @@
-module Exceptions where
+module Exceptions
+    ( TicketInfoExceptions (..)
+    , ZipFileExceptions (..)
+    ) where
 
 import Universum
 
-data ClassifierExceptions
-    = ReadZipFileException
-    | DecompressionException
+import DataSource (TicketId)
+
+data TicketInfoExceptions
+    = AttachmentNotFound TicketId
+    -- ^ Could not fetch the attachment
+    | InvalidTicketInfoException TicketId
+    -- ^ TicketInfo is invalid (both attachment and comment were not found)
+    | TicketInfoNotFound TicketId
+    -- ^ TicketInfo could not be fetched
     deriving Show
 
-instance Exception ClassifierExceptions
+data ZipFileExceptions
+    = ReadZipFileException
+    -- ^ Could not read the zip file because it was corrupted
+    | DecompressionException
+    -- ^ Decompresson of a zip file was not sucessful
+    deriving Show
+
+instance Exception TicketInfoExceptions
+instance Exception ZipFileExceptions

--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -9,15 +9,17 @@ import DataSource (TicketId(..))
 
 import Prelude (Show(..))
 
+-- | Exceptions that can occur during ticket processing
 data ProcessTicketExceptions
     = AttachmentNotFound TicketId
     -- ^ Could not fetch the attachment even though ticket info has the url of the attachment
-    | InvalidTicketInfo TicketId
-    -- ^ TicketInfo is invalid (both attachment and comment were not found)
+    | CommentAndAttachmentNotFound TicketId
+    -- ^ Both attachment and comment were not found
     | TicketInfoNotFound TicketId
     -- ^ TicketInfo could not be fetched
     deriving (Eq)
 
+-- | Exception for reading zip files
 data ZipFileExceptions
     = ReadZipFileException
     -- ^ Could not read the zip file because it was corrupted
@@ -29,9 +31,9 @@ instance Exception ProcessTicketExceptions
 instance Exception ZipFileExceptions
 
 instance Show ProcessTicketExceptions where
-    show (AttachmentNotFound tid) = "Attachment was not found on ticket ID: " <> showTicketId tid
-    show (InvalidTicketInfo tid)  = "Ticket information is invalid on ticket ID: " <> showTicketId tid
-    show (TicketInfoNotFound tid) = "Ticket information was not found on ticket ID: " <> showTicketId tid
+    show (AttachmentNotFound tid)           = "Attachment was not found on ticket ID: " <> showTicketId tid
+    show (CommentAndAttachmentNotFound tid) = "Both comment and attachment were not found on ticket ID: " <> showTicketId tid
+    show (TicketInfoNotFound tid)           = "Ticket information was not found on ticket ID: " <> showTicketId tid
 
 showTicketId :: TicketId -> String
 showTicketId tid = Universum.show (getTicketId tid)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -264,7 +264,7 @@ processTicket tId = do
     case mTicketInfo of
         Nothing -> throwM $ TicketInfoNotFound tId
         Just ticketInfo -> do
-            zendeskResponse     <- getZendeskResponses comments attachments ticketInfo
+            zendeskResponse <- getZendeskResponses comments attachments ticketInfo
 
             postTicketComment ticketInfo zendeskResponse
 
@@ -535,10 +535,10 @@ inspectAttachment Config{..} ticketInfo@TicketInfo{..} attachment = do
                 }
 
         Right logFiles -> do
-            -- Log files maybe corrupted or issue may not be found
-            eitherAnalysisResult    <- try $ extractIssuesFromLogs logFiles analysisEnv
+            -- Log files maybe corrupted or issue was not found
+            tryAnalysisResult    <- try $ extractIssuesFromLogs logFiles analysisEnv
 
-            case eitherAnalysisResult of
+            case tryAnalysisResult of
                 Right analysisResult -> do
                     -- Known issue was found
                     let errorCodes = extractErrorCodes analysisResult

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -255,7 +255,8 @@ processTicket tId = do
 
     zendeskResponse     <- getZendeskResponses comments attachments ticketInfo
 
-    whenJust zendeskResponse $ \response -> do
+    -- What should we do if the zendeskResponse was Nothing?
+    whenJust zendeskResponse $ \response -> 
         postTicketComment ticketInfo response
 
     pure zendeskResponse
@@ -473,7 +474,7 @@ inspectAttachments ticketInfo attachments = runMaybeT $ do
     att             <- MaybeT $ getAttachment lastAttachment
     let rawLog = getAttachmentContent att
 
-    -- Decompression of zip file may fail
+    -- Decompression of zip file may fail or files maybe corrupted
     eLogFiles    <- try $ extractLogsFromZip (cfgNumOfLogsToAnalyze config) rawLog
     case eLogFiles of
         Right logFiles -> pure $ inspectAttachment config ticketInfo logFiles
@@ -487,7 +488,7 @@ inspectAttachments ticketInfo attachments = runMaybeT $ do
                 }
           where
             renderErrorTag :: ClassifierExceptions -> TicketTags
-            renderErrorTag ReadZipFileException = TicketTags [renderErrorCode SentLogCorrupted]
+            renderErrorTag ReadZipFileException   = TicketTags [renderErrorCode SentLogCorrupted]
             renderErrorTag DecompressionException = TicketTags [renderErrorCode DecompressionFailure]
 
 -- | Inspection of the local zip.

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -238,7 +238,6 @@ fetchAgents = do
     mapM_ print agents
     pure agents
 
--- What should the name of this function?
 processTicketSafe :: TicketId -> App ()
 processTicketSafe tId = catch (void $ processTicket tId)
     -- Print and log any exceptions related to process ticket

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -464,7 +464,7 @@ getZendeskResponses :: [Comment] -> [Attachment] -> TicketInfo -> App ZendeskRes
 getZendeskResponses comments attachments ticketInfo
     | not (null attachments) = inspectAttachments ticketInfo attachments
     | not (null comments)    = responseNoLogs ticketInfo
-    | otherwise              = throwM $ InvalidTicketInfo (tiId ticketInfo)
+    | otherwise              = throwM $ CommentAndAttachmentNotFound (tiId ticketInfo)
     -- No attachment, no comments means something is wrong with ticket itself
 
 -- | Inspect only the latest attachment. We could propagate this

--- a/src/LogAnalysis/Exceptions.hs
+++ b/src/LogAnalysis/Exceptions.hs
@@ -1,0 +1,12 @@
+module LogAnalysis.Exceptions
+    ( LogAnalysisException(..)
+    ) where
+
+import Universum
+
+data LogAnalysisException =
+      LogReadException
+    | NoIssueFound
+    deriving Show
+
+instance Exception LogAnalysisException

--- a/src/LogAnalysis/Exceptions.hs
+++ b/src/LogAnalysis/Exceptions.hs
@@ -4,9 +4,12 @@ module LogAnalysis.Exceptions
 
 import Universum
 
+-- | Exceptions that can occur during log analysis
 data LogAnalysisException =
       LogReadException
-    | NoIssueFound
+    -- ^ Failed to read the log file because the log file was corrupted
+    | NoKnownIssueFound
+    -- ^ No known issue was found
     deriving Show
 
 instance Exception LogAnalysisException

--- a/src/LogAnalysis/Types.hs
+++ b/src/LogAnalysis/Types.hs
@@ -16,21 +16,22 @@ import qualified Data.Map.Strict as Map
 
 -- | Identifier for each error
 data ErrorCode
-    = ShortStorage       -- ^ Not enough space on hard drive to store block data
-    | UserNameError      -- ^ User is using non-latin characters for username
-    | TimeSync           -- ^ User's PC's time is out of sync
-    | FileNotFound       -- ^ Some of the files were not installed properly
-    | StaleLockFile      -- ^ Open.lock file is corrupted
-    | SentLogCorrupted   -- ^ Log file sent to the Zendesk is corrupted
-    | DBError            -- ^ Local block data is corrupted
-    | DBPath             -- ^ Daedalus cannot find certain files
-    | CannotGetDBSize    -- ^ Error message of Couidn't pack log files shows up
-    | BalanceError       -- ^ Daedalus shows wrong Ada amount
-    | NetworkError       -- ^ Firewall is blocking the connection
-    | ConnectionRefused  -- ^ Firewall is blocking the connection
-    | ResourceVanished   -- ^ Network error
-    | Unknown            -- ^ Unknown error (currently not used)
-    | Error              -- ^ Error (currently not used)
+    = ShortStorage         -- ^ Not enough space on hard drive to store block data
+    | UserNameError        -- ^ User is using non-latin characters for username
+    | TimeSync             -- ^ User's PC's time is out of sync
+    | FileNotFound         -- ^ Some of the files were not installed properly
+    | StaleLockFile        -- ^ Open.lock file is corrupted
+    | SentLogCorrupted     -- ^ Log file sent to the Zendesk is corrupted
+    | DBError              -- ^ Local block data is corrupted
+    | DBPath               -- ^ Daedalus cannot find certain files
+    | CannotGetDBSize      -- ^ Error message of Couidn't pack log files shows up
+    | BalanceError         -- ^ Daedalus shows wrong Ada amount
+    | NetworkError         -- ^ Firewall is blocking the connection
+    | ConnectionRefused    -- ^ Firewall is blocking the connection
+    | ResourceVanished     -- ^ Network error
+    | DecompressionFailure -- ^ The classifier failed to decompress the log file
+    | Unknown              -- ^ Unknown error (currently not used)
+    | Error                -- ^ Error (currently not used)
     deriving (Eq, Ord, Show)
 
 -- | Record identifying the issue
@@ -57,22 +58,25 @@ instance Show Knowledge where
         "}"
 
 -- | Sorted accoring to knowledgebase.
+-- Tag needs to be in lowercase since Zendesk automatically convert any uppercase
+-- lowercase
 renderErrorCode :: ErrorCode -> Text
-renderErrorCode DBError           = "DB-corrupted"
-renderErrorCode StaleLockFile     = "stale-lock-file"
-renderErrorCode FileNotFound      = "directory-not-found"
-renderErrorCode ShortStorage      = "short-storage"
-renderErrorCode NetworkError      = "network-error"
-renderErrorCode BalanceError      = "incorrect-balance"
-renderErrorCode ResourceVanished  = "resource-vanished"
-renderErrorCode UserNameError     = "user-name-error"
-renderErrorCode ConnectionRefused = "connection-refused"
-renderErrorCode TimeSync          = "time-out-of-sync"
-renderErrorCode SentLogCorrupted  = "sent-log-corrupted"
-renderErrorCode DBPath            = "DB-path-error"
-renderErrorCode CannotGetDBSize   = "cannot-get-db-size"
-renderErrorCode Unknown           = "unknown"
-renderErrorCode Error             = "error"
+renderErrorCode DBError              = "db-corrupted"
+renderErrorCode StaleLockFile        = "stale-lock-file"
+renderErrorCode FileNotFound         = "directory-not-found"
+renderErrorCode ShortStorage         = "short-storage"
+renderErrorCode NetworkError         = "network-error"
+renderErrorCode BalanceError         = "incorrect-balance"
+renderErrorCode ResourceVanished     = "resource-vanished"
+renderErrorCode UserNameError        = "user-name-error"
+renderErrorCode ConnectionRefused    = "connection-refused"
+renderErrorCode TimeSync             = "time-out-of-sync"
+renderErrorCode SentLogCorrupted     = "sent-log-corrupted"
+renderErrorCode DBPath               = "db-path-error"
+renderErrorCode CannotGetDBSize      = "cannot-get-db-size"
+renderErrorCode DecompressionFailure = "decompression-failure"
+renderErrorCode Unknown              = "unknown"
+renderErrorCode Error                = "error"
 
 toComment :: ErrorCode -> Text
 toComment SentLogCorrupted = "Log file is corrupted"

--- a/src/LogAnalysis/Types.hs
+++ b/src/LogAnalysis/Types.hs
@@ -83,7 +83,7 @@ toComment SentLogCorrupted = "Log file is corrupted"
 toComment _                = "Error"
 
 -- | Map used to collect error lines
-type Analysis = Map Knowledge [LText]
+type Analysis = Map Knowledge [Text]
 
 -- | Create initial analysis environment
 setupAnalysis :: [Knowledge] -> Analysis

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -9,7 +9,7 @@ import qualified Codec.Archive.Zip as Zip
 import qualified Data.Map.Strict as Map
 import Control.Exception.Safe (tryDeep)
 
-import Exceptions (ClassifierExceptions(..))
+import Exceptions (ZipFileExceptions(..))
 
 -- | Extract log file from given zip file
 -- TODO(ks): What happens with the other files? We just ignore them?

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -7,13 +7,12 @@ import           Universum
 
 import qualified Codec.Archive.Zip as Zip
 import qualified Data.Map.Strict as Map
-import Control.Exception.Safe (tryDeep)
 
 import Exceptions (ZipFileExceptions(..))
 
 -- | Extract log file from given zip file
 -- TODO(ks): What happens with the other files? We just ignore them?
-extractLogsFromZip :: (MonadCatch m, MonadIO m) => Int -> LByteString -> m [LByteString]
+extractLogsFromZip :: Int -> LByteString -> Either ZipFileExceptions [LByteString]
 extractLogsFromZip numberOfFiles file = do
     zipMap <- readZip file  -- Read File
     let extractedLogs = Map.elems $ mTake numberOfFiles zipMap  -- Extract selected logs
@@ -27,14 +26,10 @@ extractLogsFromZip numberOfFiles file = do
 -- upwards
 -- Why tryDeep instead of try? It's because we need to fully evaluate bytestrings in order to catch
 -- the decompression issue.
-readZip :: (MonadCatch m, MonadIO m) => LByteString -> m (Map FilePath LByteString)
+readZip :: LByteString -> Either ZipFileExceptions (Map FilePath LByteString)
 readZip rawzip = case Zip.toArchiveOrFail rawzip of
-    Left _      -> throwM ReadZipFileException
-    Right archive -> do
-      eArchive <- tryDeep (pure $ finishProcessing archive)
-      case eArchive of
-        Left (_ :: SomeException) -> throwM DecompressionException
-        Right files -> return files 
+    Left _      -> Left ReadZipFileException
+    Right archive -> return $ finishProcessing archive
   where
     finishProcessing :: Zip.Archive -> Map FilePath LByteString
     finishProcessing = Map.fromList . map handleEntry . Zip.zEntries

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -8,9 +8,10 @@ import           Universum
 import qualified Codec.Archive.Zip as Zip
 import qualified Data.Map.Strict as Map
 
+import Exceptions (ClassifierExceptions(..))
 -- | Extract log file from given zip file
 -- TODO(ks): What happens with the other files? We just ignore them?
-extractLogsFromZip :: Int -> LByteString -> Either Text [LByteString]
+extractLogsFromZip :: Int -> LByteString -> Either ClassifierExceptions [LByteString]
 extractLogsFromZip numberOfFiles file = do
     zipMap <- readZip file  -- Read File
     let extractedLogs = Map.elems $ mTake numberOfFiles zipMap  -- Extract selected logs
@@ -20,9 +21,9 @@ extractLogsFromZip numberOfFiles file = do
     mTake n = Map.fromDistinctAscList . take n . Map.toAscList
 
 -- | Read zipe file
-readZip :: LByteString -> Either Text (Map FilePath LByteString)
+readZip :: LByteString -> Either ClassifierExceptions (Map FilePath LByteString)
 readZip rawzip = case Zip.toArchiveOrFail rawzip of
-    Left err      -> Left (toText err)
+    Left err      -> Left $ ReadZipFileException (toText err)
     Right archive -> Right $ finishProcessing archive
   where
     finishProcessing :: Zip.Archive -> Map FilePath LByteString

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -8,7 +8,7 @@ import           Universum
 import qualified Codec.Archive.Zip as Zip
 import qualified Data.Map.Strict as Map
 
-import Exceptions (ZipFileExceptions(..))
+import           Exceptions (ZipFileExceptions (..))
 
 -- | Extract log file from given zip file
 -- TODO(ks): What happens with the other files? We just ignore them?
@@ -22,13 +22,10 @@ extractLogsFromZip numberOfFiles file = do
     mTake n = Map.fromDistinctAscList . take n . Map.toAscList
 
 -- | Read zipe file
--- toArchiveOrFail is a partial function, we need to use tryDeep to catch the exception and throw it 
--- upwards
--- Why tryDeep instead of try? It's because we need to fully evaluate bytestrings in order to catch
--- the decompression issue.
+-- toArchiveOrFail is a partial function, so be careful.
 readZip :: LByteString -> Either ZipFileExceptions (Map FilePath LByteString)
 readZip rawzip = case Zip.toArchiveOrFail rawzip of
-    Left _      -> Left ReadZipFileException
+    Left _        -> Left ReadZipFileException
     Right archive -> return $ finishProcessing archive
   where
     finishProcessing :: Zip.Archive -> Map FilePath LByteString

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -59,6 +59,7 @@ withStubbedIOAndZendeskLayer stubbedZendeskLayer =
     stubbedIOLayer =
         basicIOLayer
             { iolPrintText      = \_     -> pure ()
+            , iolAppendFile     = \_ _   -> pure ()
             -- ^ Do nothing with the output
             }
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -225,7 +225,6 @@ processTicketSpec =
                     eZendeskResponse <- run (try appExecution)
 
                     -- Check it throws exception
-                    -- How do I check if it returns proper exception?
                     assert $ isLeft (eZendeskResponse :: Either ProcessTicketExceptions ZendeskResponse)
                     whenLeft eZendeskResponse $ \processException ->
                         assert $ processException == CommentAndAttachmentNotFound (tiId ticketInfo)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -149,7 +149,7 @@ processTicketSpec =
                         zendeskResponse <- run appExecution
 
                         -- Check we have some comments.
-                        assert $ (not . null . zrComment) zendeskResponse
+                        assert . not . null . zrComment $ zendeskResponse
 
         it "processes ticket, with no attachments" $
             forAll (listOf1 genCommentWithNoAttachment) $ \(commentsWithoutAttachment :: [Comment]) ->
@@ -172,7 +172,7 @@ processTicketSpec =
 
                     zendeskResponse <- run appExecution
 
-                    assert $ (not . null . zrComment) zendeskResponse
+                    assert . not . null . zrComment $ zendeskResponse
                     assert $ isResponseTaggedWithNoLogs zendeskResponse
 
         it "processes ticket, with attachments" $
@@ -199,8 +199,8 @@ processTicketSpec =
 
                     zendeskResponse <- run appExecution
 
-                    assert $ (not . null . zrComment) zendeskResponse
-                    assert $ not (isResponseTaggedWithNoLogs zendeskResponse)
+                    assert . not . null . zrComment $ zendeskResponse
+                    assert . not . isResponseTaggedWithNoLogs $ zendeskResponse
 
         it "tries to process ticket but cannot find both comments and attachments, throws exception" $
             forAll arbitrary $ \(ticketInfo :: TicketInfo) ->


### PR DESCRIPTION
This PR will introduce exception handling on reading log files so that the program will not crash due to the corrupted log file.

- Fix test cases (Don't use external file when testing)
- Exception handling on reading log files. (Example tciket id: 15066)

https://iohk.myjetbrains.com/youtrack/issue/TSD-70