### PR TITLE
[TSD-77] Fix two documentation issues that caused Hoogle to break

### DIFF
--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -645,7 +645,7 @@ instance FromPageResultList TicketInfo where
         , exportTicketsParser obj
         ]
       where
-          -- | The case when we have the simple parser from tickets.
+        -- | The case when we have the simple parser from tickets.
         ticketListParser :: Value -> Parser (PageResultList TicketInfo)
         ticketListParser = withObject "ticketList" $ \o ->
             PageResultList
@@ -808,4 +808,3 @@ renderTicketStatus AnalyzedByScriptV1_0 = "analyzed-by-script-v1.0"
 renderTicketStatus AnalyzedByScriptV1_1 = "analyzed-by-script-v1.1"
 renderTicketStatus NoKnownIssue         = "no-known-issues"
 renderTicketStatus NoLogAttached        = "no-log-files"
-

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -556,7 +556,7 @@ filterAnalyzedTickets ticketsInfo =
     unsolvedTicketStatus = map TicketStatus ["new", "open", "hold", "pending"]
 
     isTicketOpen :: TicketInfo -> Bool
-    isTicketOpen TicketInfo{..} = tiStatus `elem` unsolvedTicketStatus-- || ticketStatus == "new"
+    isTicketOpen TicketInfo{..} = tiStatus `elem` unsolvedTicketStatus-- ^ ticketStatus == "new"
 
     -- | If we have a ticket we are having issues with...
     isTicketBlacklisted :: TicketInfo -> Bool

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -556,7 +556,7 @@ filterAnalyzedTickets ticketsInfo =
     unsolvedTicketStatus = map TicketStatus ["new", "open", "hold", "pending"]
 
     isTicketOpen :: TicketInfo -> Bool
-    isTicketOpen TicketInfo{..} = tiStatus `elem` unsolvedTicketStatus-- ^ ticketStatus == "new"
+    isTicketOpen TicketInfo{..} = tiStatus `elem` unsolvedTicketStatus
 
     -- | If we have a ticket we are having issues with...
     isTicketBlacklisted :: TicketInfo -> Bool


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/issue/TSD-77

Hoogle cannot generate documentation for the log-classifier project due to incorrect documentation formatting in two places. These need to be fixed so that Hoogle can be used with the project.