### PR TITLE
Nix builds work

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -30,9 +30,23 @@ nix-shell $ ghcid -c "runhaskell Setup.hs repl Lib"
 ```
 
 ## To change version of nixpkgs
+Get $REV from https://howoldis.herokuapp.com/
+```
+$ REV="d7d31fea7e7eef8ff4495e75be5dcbb37fb215d0"
+$ SHA=`nix-prefetch-url https://github.com/nixos/nixpkgs/archive/${REV}.tar.gz`
+$ SHA-UNPACK=`nix-prefetch-url --unpack https://github.com/nixos/nixpkgs/archive/${REV}.tar.gz`
+$ source nix-pkgs.sh > nix-pkgs.json
+```
+nix-pkgs-sh
+```
+echo '
+{
+    "rev":            "$REV",
+    "sha256":         "$SHA",
+    "sha256unpacked": "$SHA-UNPACK"
+}'
 
-
-:wq
+```
 
 ## To get versions
 ```

--- a/CI.md
+++ b/CI.md
@@ -1,5 +1,25 @@
 # Buildkite & Nix Builds
 
+## Nix related files and their purposes
+
+default.nix 
+  - Contains the primary nix expression used to build log-classifier. This is the only nix expression that a developer may need to modify.
+cabal2nix.nix 
+  - The cabal2nix generated output from the log-classifier.cabal file.
+fetch-nixpkgs.nix 
+  - Used for pinning a specific version of nixpkgs
+fetchNixpkgs.nix
+  - Used for pinning a specific version of nixpkgs
+lib.nix
+  - Used for pinning a specific verison of nixpkgs
+shell.nix
+  - Used by nix-shell to set nix environment
+universum.nix
+  - created by cabal2nix, essentially overrides the Universum in nixpkgs
+nixpkgs-src.json
+  - Where version of nixpkgs is defined. See below for instructions to update.
+
+
 ## Buildkite
 The buildkite pipeline is automatically triggered by any commits that are pushed to the log-classifier repo.
 The pipeline that is executed is located in the .buildkite folder.
@@ -29,8 +49,25 @@ $ nix-shell
 nix-shell $ ghcid -c "runhaskell Setup.hs repl Lib"
 ```
 
+## If log-classifier.cabal file is modified
+
+Execute the following:
+
+```
+$ cabal2nix . > cabal2nix.nix
+```
+
+## If Universum version needs to be changed
+
+```
+$ cabal2nix cabal://universum-1.1.0 > universum.nix
+```
+
+
 ## To change version of nixpkgs
+
 Get $REV from https://howoldis.herokuapp.com/
+
 ```
 $ REV="d7d31fea7e7eef8ff4495e75be5dcbb37fb215d0"
 $ SHA=`nix-prefetch-url https://github.com/nixos/nixpkgs/archive/${REV}.tar.gz`

--- a/CI.md
+++ b/CI.md
@@ -28,3 +28,13 @@ $ nix-env -f '<nixpkgs>' -iA haskellPackages.ghcid
 $ nix-shell
 nix-shell $ ghcid -c "runhaskell Setup.hs repl Lib"
 ```
+
+## To change version of nixpkgs
+
+
+:wq
+
+## To get versions
+```
+nix-shell --run 'ghc-pkg list' | grep universum
+```

--- a/CI.md
+++ b/CI.md
@@ -1,14 +1,30 @@
-# Buildkite
+# Buildkite & Nix Builds
 
-These are the instructions for generating nix expressions for buildkite CI for log-classifier.
+## Buildkite
+The buildkite pipeline is automatically triggered by any commits that are pushed to the log-classifier repo.
+The pipeline that is executed is located in the .buildkite folder.
+
+## Nix
+
+These are the instructions for using nix to build log-classifier.
+
+All the commands below are executed in the cloned log-classifier directory.
 
 ```
-$ cd $LOG_CLASSIFIER_ROOT
-$ cabal2nix . > default.nix
-$ nix-shell -p nix-prefetch-git
-nix-shell $ nix-prefetch-git https://github.com/NixOS/nixpkgs.git > nixpkgs.json
+$ nix build -f default.nix
 ```
 
-NOTE: 
-  - NIX_PATH - Get from https://github.com/NixOS/nixpkgs, click clone, copy ZIP link, rename to .tar.gz.
-  - buildkite pipeline command is "nix-build -I nixpkgs=$NIX_PATH shell.nix"
+You can also build within nix-shell: 
+
+```
+$ nix-shell
+nix-shell $ runhaskell Setup.hs configure
+nix-shell $ runhaskell Setup.hs build
+```
+
+If you would prefer to use the repl:
+```
+$ nix-env -f '<nixpkgs>' -iA haskellPackages.ghcid
+$ nix-shell
+nix-shell $ ghcid -c "runhaskell Setup.hs repl Lib"
+```

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,17 @@
-let lib = import ./lib.nix;
+let
+  config = {
+    packageOverrides = pkgs: rec {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          universum =
+            haskellPackagesNew.callPackage ./universum.nix { };
+        };
+      };
+    };
+  };
 
-    pkgs = import lib.fetchNixPkgs {};
+  lib = import ./lib.nix;
+
+  pkgs = import lib.fetchNixPkgs {inherit config; };
 in
   pkgs.haskell.packages.ghc822.callPackage ./cabal2nix.nix {}

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 let
   config = {
     packageOverrides = pkgs: rec {
-      haskellPackages = pkgs.haskellPackages.override {
+      haskellPackages = pkgs.haskell.packages.ghc822.override {
         overrides = haskellPackagesNew: haskellPackagesOld: rec {
           universum =
             haskellPackagesNew.callPackage ./universum.nix { };
@@ -14,4 +14,4 @@ let
 
   pkgs = import lib.fetchNixPkgs {inherit config; };
 in
-  pkgs.haskell.packages.ghc822.callPackage ./cabal2nix.nix {}
+  pkgs.haskellPackages.callPackage ./cabal2nix.nix {}

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,5 +1,7 @@
+ 
 {
-    "rev":            "d6c6c7fcec6dbd2b8ab14f0b35d56c7733872baa",
-    "sha256":         "0khsq4j7lrxf5dhgsi27ms9lqwqi3lbv2461kw73f82r6dw44v9x",
-    "sha256unpacked": "1bq59575b58lmh5w8bh7pwp17c3p2nm651bz1i3q224c4zsj9294"
+    "rev":            "d7d31fea7e7eef8ff4495e75be5dcbb37fb215d0",
+    "sha256":         "013na1m4g8c3rcfw0dwmv2zmia6byg5c2xdx3z5dk90i27s449kx",
+    "sha256unpacked": "1ghb1nhgfx3r2rl501r8k0akmfjvnl9pis92if35pawsxgp115kv"
+
 }

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,5 +1,5 @@
 {
-    "rev":            "120b013e0c082d58a5712cde0a7371ae8b25a601",
-    "sha256":         "1hbc3ng4iy4wv0kyr1zc7n4qx3wy5qlank42zq8h87wa8z3zdf14",
-    "sha256unpacked": "0hk4y2vkgm1qadpsm4b0q1vxq889jhxzjx3ragybrlwwg54mzp4f"
+    "rev":            "d6c6c7fcec6dbd2b8ab14f0b35d56c7733872baa",
+    "sha256":         "0khsq4j7lrxf5dhgsi27ms9lqwqi3lbv2461kw73f82r6dw44v9x",
+    "sha256unpacked": "1bq59575b58lmh5w8bh7pwp17c3p2nm651bz1i3q224c4zsj9294"
 }

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,7 +1,5 @@
- 
 {
-    "rev":            "d7d31fea7e7eef8ff4495e75be5dcbb37fb215d0",
-    "sha256":         "013na1m4g8c3rcfw0dwmv2zmia6byg5c2xdx3z5dk90i27s449kx",
-    "sha256unpacked": "1ghb1nhgfx3r2rl501r8k0akmfjvnl9pis92if35pawsxgp115kv"
-
+    "rev":            "120b013e0c082d58a5712cde0a7371ae8b25a601",
+    "sha256":         "1hbc3ng4iy4wv0kyr1zc7n4qx3wy5qlank42zq8h87wa8z3zdf14",
+    "sha256unpacked": "0hk4y2vkgm1qadpsm4b0q1vxq889jhxzjx3ragybrlwwg54mzp4f"
 }

--- a/universum.nix
+++ b/universum.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, base, bytestring, containers, criterion, deepseq
+, doctest, ghc-prim, Glob, hashable, hedgehog, microlens
+, microlens-mtl, mtl, safe-exceptions, semigroups, stdenv, stm
+, tasty, tasty-hedgehog, text, text-format, transformers
+, type-operators, unordered-containers, utf8-string, vector
+}:
+mkDerivation {
+  pname = "universum";
+  version = "1.1.0";
+  sha256 = "177635a009f38edb8fc764bf9504077fb41af033c49b2a0ae2c725b55a9a2f4c";
+  libraryHaskellDepends = [
+    base bytestring containers deepseq ghc-prim hashable microlens
+    microlens-mtl mtl safe-exceptions stm text text-format transformers
+    type-operators unordered-containers utf8-string vector
+  ];
+  testHaskellDepends = [
+    base bytestring doctest Glob hedgehog tasty tasty-hedgehog text
+    utf8-string
+  ];
+  benchmarkHaskellDepends = [
+    base containers criterion deepseq hashable mtl semigroups text
+    unordered-containers
+  ];
+  homepage = "https://github.com/serokell/universum";
+  description = "Custom prelude used in Serokell";
+  license = stdenv.lib.licenses.mit;
+}


### PR DESCRIPTION
Nix builds work now with proper versioning of Universum 1.1.0 and GHC 8.2.2

CI.md details what all of the nix files actually do and the various processes that devs may need to go through (how to update Universum, cabal file updates, nixpkgs updates etc).