### PR TITLE
[TSD-90] Return strict bytestring instead of lazy bytestring

### DIFF
--- a/src/LogAnalysis/Classifier.hs
+++ b/src/LogAnalysis/Classifier.hs
@@ -13,7 +13,6 @@ module LogAnalysis.Classifier
 
 import           Universum
 
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import           Data.Text (isInfixOf)
 import           Data.Text.Encoding.Error (ignore)
@@ -27,17 +26,17 @@ numberOfErrorText :: Int
 numberOfErrorText = 3
 
 -- | Analyze each log file based on the knowlodgebases' data.
-extractIssuesFromLogs :: (MonadCatch m) => [LByteString] -> Analysis -> m Analysis
+extractIssuesFromLogs :: (MonadCatch m) => [ByteString] -> Analysis -> m Analysis
 extractIssuesFromLogs files analysis = do
     analysisResult <- foldlM runClassifiers analysis files
     filterAnalysis analysisResult
 
 -- | Run analysis on given file
-runClassifiers :: (MonadCatch m) => Analysis -> LByteString -> m Analysis
+runClassifiers :: (MonadCatch m) => Analysis -> ByteString -> m Analysis
 runClassifiers analysis logfile = do
     -- Force the evaluation of the whole file.
     strictLogfile <- catchAnyStrict (pure logfile) $ \_ -> throwM LogReadException
-    pure . foldl' analyzeLine analysis . lines . decodeUtf8With ignore . LBS.toStrict $ strictLogfile
+    pure . foldl' analyzeLine analysis . lines . decodeUtf8With ignore $ strictLogfile
   where
 
     -- | A helpful utility function.

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -6,16 +6,18 @@ module Util
 import           Universum
 
 import qualified Codec.Archive.Zip as Zip
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 
 import           Exceptions (ZipFileExceptions (..))
 
 -- | Extract log file from given zip file
 -- TODO(ks): What happens with the other files? We just ignore them?
-extractLogsFromZip :: Int -> LByteString -> Either ZipFileExceptions [LByteString]
+extractLogsFromZip :: Int -> LByteString -> Either ZipFileExceptions [ByteString]
 extractLogsFromZip numberOfFiles file = do
     zipMap <- readZip file  -- Read File
-    let extractedLogs = Map.elems $ mTake numberOfFiles zipMap  -- Extract selected logs
+    let extractedLogs :: [ByteString]
+        extractedLogs = map LBS.toStrict . Map.elems . mTake numberOfFiles $ zipMap
     return extractedLogs
   where
     mTake :: Int -> Map k a -> Map k a


### PR DESCRIPTION
## Related ticket
https://iohk.myjetbrains.com/youtrack/issue/TSD-90

To reduce the memory consumption, only the log files that will be analyzed will be converted to strict bytestring