### PR TITLE
[TSD-96] Fix getAttachmentsFromComment

### DIFF
--- a/src/DataSource/Types.hs
+++ b/src/DataSource/Types.hs
@@ -499,7 +499,8 @@ instance Arbitrary Attachment where
     arbitrary = Attachment
         <$> arbitrary
         <*> pure "http://attach.com"
-        <*> pure "application/zip"  -- TODO(ks): More random...
+        -- TODO(ks): More random...
+        <*> elements ["application/zip", "application/x-zip-compressed"]
         <*> arbitrary
 
 instance Arbitrary CommentBody where

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -5,6 +5,7 @@ module Lib
     ( runZendeskMain
     , collectEmails
     , getZendeskResponses
+    , getAttachmentsFromComment
     , processTicket
     , processTicketSafe
     , processTickets
@@ -477,7 +478,8 @@ getAttachmentsFromComment comments = do
 
     -- Readability
     isAttachmentZip :: Attachment -> Bool
-    isAttachmentZip attachment = "application/zip" == aContentType attachment
+    isAttachmentZip attachment = aContentType attachment `elem`
+        ["application/zip", "application/x-zip-compressed"]
 
 -- | Inspects the comment, attachment, ticket info and create 'ZendeskResponse'
 getZendeskResponses :: [Comment] -> [Attachment] -> TicketInfo -> App ZendeskResponse


### PR DESCRIPTION
YouTrack: https://iohk.myjetbrains.com/youtrack/issue/TSD-96

Currently, the classifier skips any zip file with the content type of `application/x-zip-compress` (More details are here: https://iohk.myjetbrains.com/youtrack/issue/TSD-94#comment=93-26314). This PR will fix this issue.