### PR TITLE
[TSD-138] Analyze ticket even if already been analyzed

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -280,7 +280,7 @@ processTicket tId = do
             zendeskResponse <- getZendeskResponses comments attachments ticketInfo
 
             postTicketComment ticketInfo zendeskResponse
-
+            
             -- TODO(ks): Moved back so we can run it in single-threaded mode. Requires a lot of
             -- refactoring to run it in a multi-threaded mode.
             let ticketId = getTicketId $ zrTicketId zendeskResponse
@@ -341,8 +341,15 @@ processTicketsFromTime exportFromTime = do
 processTickets :: HasCallStack => App ()
 processTickets = do
 
-    allTickets          <- fetchTickets
-    _                   <- mapM (processTicketSafe . tiId) allTickets
+    printText <- asksIOLayer iolPrintText
+    printText "Classifier will start processing tickets"
+    
+    -- Fetching all the tickets that needs to be processed
+    allTickets <- fetchTickets
+
+    printText $ "Number of tickets to be analyzed: " <> show (length allTickets)
+
+    mapM_ (processTicketSafe . tiId) allTickets
 
     putTextLn "All the tickets has been processed."
 
@@ -420,17 +427,11 @@ listAndSortTickets = do
         agentIds = map uId agents
     -- We first fetch the function from the configuration
     listTickets <- asksDataLayer zlListAssignedTickets
-    printText   <- asksIOLayer iolPrintText
-
-    printText "Classifier is going to process tickets assigned to agents"
 
     ticketInfos <- map concat $ traverse listTickets agentIds
 
     let filteredTicketIds = filterAnalyzedTickets ticketInfos
     let sortedTicketIds   = sortBy compare filteredTicketIds
-
-    printText $ "There are " <> show (length sortedTicketIds) <> " unanalyzed tickets."
-    printText "Processing tickets, this may take hours to finish."
 
     pure sortedTicketIds
 
@@ -439,17 +440,11 @@ listAndSortUnassignedTickets = do
 
     -- We first fetch the function from the configuration
     listUnassignedTickets   <- asksDataLayer zlListUnassignedTickets
-    printText               <- asksIOLayer iolPrintText
-
-    printText "Classifier is going to process tickets assigned to agents"
 
     ticketInfos             <- listUnassignedTickets
 
     let filteredTicketIds   = filterAnalyzedTickets ticketInfos
     let sortedTicketIds     = sortBy compare filteredTicketIds
-
-    printText $ "There are " <> show (length sortedTicketIds) <> " unanalyzed and unassigned tickets."
-    printText "Processing tickets, this may take hours to finish."
 
     pure sortedTicketIds
 
@@ -625,28 +620,9 @@ filterAnalyzedTickets ticketsInfo =
   where
     ticketsFilter :: TicketInfo -> Bool
     ticketsFilter ticketInfo =
-           isTicketAnalyzed ticketInfo
-        && isTicketOpen ticketInfo
+           isTicketOpen ticketInfo
         && isTicketBlacklisted ticketInfo
         && isTicketInGoguenTestnet ticketInfo
-
-    analyzedTags :: [Text]
-    analyzedTags = map renderTicketStatus
-                        [ AnalyzedByScriptV1_0
-                        , AnalyzedByScriptV1_1
-                        , AnalyzedByScriptV1_2
-                        , AnalyzedByScriptV1_3
-                        , AnalyzedByScriptV1_4
-                        , AnalyzedByScriptV1_4_1
-                        , AnalyzedByScriptV1_4_2
-                        , AnalyzedByScriptV1_4_3
-                        , AnalyzedByScriptV1_4_4
-                        , AnalyzedByScriptV1_4_5
-                        ]
-
-    isTicketAnalyzed :: TicketInfo -> Bool
-    isTicketAnalyzed TicketInfo{..} = all (\analyzedTag -> analyzedTag `notElem` (getTicketTags tiTags)) analyzedTags
-    -- ^ This is showing that something is wrong...
 
     unsolvedTicketStatus :: [TicketStatus]
     unsolvedTicketStatus = map TicketStatus ["new", "open", "hold", "pending"]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -581,11 +581,6 @@ filterAnalyzedTicketsSpec =
                 \(ticketInfos :: [TicketInfo]) ->
                     length (filterAnalyzedTickets ticketInfos) `shouldBe` 0
 
-        it "should filter analyzed tickets" $
-            forAll (listOf $ genTicketWithFilteredTags ["analyzed-by-script-v1.0"]) $
-                \(ticketInfos :: [TicketInfo]) ->
-                    length (filterAnalyzedTickets ticketInfos) `shouldBe` 0
-
 createResponseTicketSpec :: Spec
 createResponseTicketSpec =
     describe "createResponseTicket" $ modifyMaxSuccess (const 200) $ do


### PR DESCRIPTION
Youtrack Link
https://iohk.myjetbrains.com/youtrack/issue/TSD-138

I've also removed some of the text since it was misleading. (Though classifier processed only X tickets, console state that it will process Y tickets.) 