### PR TITLE
[TSD-144] Improvements on handling corrupted log file.

### DIFF
--- a/src/Exceptions.hs
+++ b/src/Exceptions.hs
@@ -1,5 +1,6 @@
 module Exceptions
-    ( ProcessTicketExceptions (..)
+    ( ClassifierExceptions (..)
+    , ProcessTicketExceptions (..)
     , ZipFileExceptions (..)
     ) where
 
@@ -27,8 +28,15 @@ data ZipFileExceptions
     -- ^ Decompresson of a zip file was not sucessful
     deriving Show
 
+-- | Exception on running log-classifier
+data ClassifierExceptions
+    = FailedToReadAssignFile
+    | FailedToParseKnowledgebase
+    deriving (Show)
+
 instance Exception ProcessTicketExceptions
 instance Exception ZipFileExceptions
+instance Exception ClassifierExceptions
 
 instance Show ProcessTicketExceptions where
     show (AttachmentNotFound tid)           = "Attachment was not found on ticket ID: " <> showTicketId tid

--- a/src/LogAnalysis/Classifier.hs
+++ b/src/LogAnalysis/Classifier.hs
@@ -34,15 +34,15 @@ extractIssuesFromLogs :: (MonadCatch m) => [LogFile] -> Analysis -> m Analysis
 extractIssuesFromLogs logFiles analysis = do
 
     -- Will raise exception if we find an issue.
-    _                   <- mapM (checkFile . getLogFileContent) logFiles
+    _  <- checkFiles $ map getLogFileContent logFiles
 
     logLines            <- concatMapM extractMessages logFiles
     let analysisResult  = foldl' analyzeLine analysis logLines
     filterAnalysis analysisResult
   where
-    -- Force the evaluation of the whole file.
-    checkFile :: (MonadCatch m) => ByteString -> m ByteString
-    checkFile logfile = catchAnyStrict (pure logfile) $ \_ -> throwM LogReadException
+    -- Force the evaluation on list of files
+    checkFiles :: (MonadCatch m) => [ByteString] -> m [ByteString]
+    checkFiles logfiles = catchAnyStrict (pure logfiles) $ \_ -> throwM LogReadException
     -- | A helpful utility function.
     -- TODO(ks): Maybe move it to Util?
     catchAnyStrict :: (MonadCatch m, NFData a) => m a -> (SomeException -> m a) -> m a


### PR DESCRIPTION
YT issue: https://iohk.myjetbrains.com/youtrack/issue/TSD-144

It seems like the program fails when we try to evaluate **list** of log files since zip extraction function returns `error` instead of list of files with some of them being an `error`

I did try processing all the previous tickets where we had issues and it was working properly.